### PR TITLE
Main Entry marked wrong

### DIFF
--- a/lesson-2-containers/exercises/debugging-containers/package.json
+++ b/lesson-2-containers/exercises/debugging-containers/package.json
@@ -2,7 +2,7 @@
   "name": "simple_node",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/lesson-2-containers/exercises/simple-node/package.json
+++ b/lesson-2-containers/exercises/simple-node/package.json
@@ -2,7 +2,7 @@
   "name": "simple_node",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/lesson-2-containers/exercises/slow-node/package.json
+++ b/lesson-2-containers/exercises/slow-node/package.json
@@ -2,7 +2,7 @@
   "name": "simple_node",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
It is fairly to be noticed that main entry must be configured poperly because most of the time code developer could run the command : node .
So, it's better to have correct scrits in package.json